### PR TITLE
fix(uninstall): harden uninstall flow and fail closed

### DIFF
--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -24,58 +24,174 @@
 
 #  This script uninstalls Bootstrap Buddy.
 
-AuthDBTeardown() {
-    # Create temporary directory for storage of authorization database files
-    # Using hyphen to prevent escape issues in PlistBuddy commands
-    BB_DIR="${TMPDIR:=/private/tmp}/com.inetum.Bootstrap-Buddy"
-    mkdir -pv "$BB_DIR"
-    AUTH_DB="$BB_DIR/auth.db"
+set -euo pipefail
 
-    # Output current loginwindow auth database
-    echo "Reading system.login.console section of authorization database..."
-    /usr/bin/security authorizationdb read system.login.console > "$AUTH_DB"
-    if [[ ! -f "$AUTH_DB" ]]; then
-        echo "ERROR: Unable to save the current authorization database."
-        exit 1
-    fi
+readonly AUTH_DB_SECTION="system.login.console"
+readonly MECHANISM_LABEL="Bootstrap Buddy:Invoke,privileged"
+readonly RECEIPT_ID="com.inetum.Bootstrap-Buddy"
+readonly BUNDLE_PATH="/Library/Security/SecurityAgentPlugins/Bootstrap Buddy.bundle"
+readonly BUNDLED_TEARDOWN="${BUNDLE_PATH}/Contents/Resources/AuthDBTeardown.sh"
 
-    # Check current loginwindow auth database for desired entry
-    if ! grep -q '<string>Bootstrap Buddy:Invoke,privileged</string>' "$AUTH_DB"; then
-        echo "Bootstrap Buddy is not configured in the loginwindow authorization database."
-        return
-    fi
+BB_DIR=""
+AUTH_DB=""
 
-    # Create a backup copy
-    cp "$AUTH_DB" "$AUTH_DB.backup"
+log() {
+    echo "$1"
+}
 
-    echo "Removing Bootstrap Buddy from authorization database..."
-    INDEX=$(/usr/libexec/PlistBuddy -c "Print :mechanisms:" "$AUTH_DB" 2>/dev/null | grep -n "Bootstrap Buddy:Invoke,privileged" | awk -F ":" '{print $1}')
-    if [[ -z $INDEX ]]; then
-        echo "ERROR: Unable to index current loginwindow authorization database."
-        exit 1
-    fi
+fail() {
+    echo "ERROR: $1" >&2
+    exit 1
+}
 
-    # Subtract 2 from the index to account for PlistBuddy output format
-    INDEX=$((INDEX-2))
-
-    # Remove Bootstrap Buddy mechanism
-    /usr/libexec/PlistBuddy -c "Delete :mechanisms:$INDEX" "$AUTH_DB"
-
-    # Save authorization database changes
-    if ! security authorizationdb write system.login.console < "$AUTH_DB"; then
-        echo "ERROR: Unable to save changes to authorization database."
-        exit 1
+cleanup() {
+    if [[ -n "${BB_DIR}" && -d "${BB_DIR}" ]]; then
+        rm -rf "${BB_DIR}"
     fi
 }
 
-# If in-bundle AuthDB teardown script exists on disk, prefer using that
-echo "Removing Bootstrap Buddy from authorization database..."
-"/Library/Security/SecurityAgentPlugins/Bootstrap Buddy.bundle/Contents/Resources/AuthDBTeardown.sh" || AuthDBTeardown
+require_root() {
+    if [[ $EUID -ne 0 ]]; then
+        fail "This script must be run as root."
+    fi
+}
 
-echo "Deleting Bootstrap Buddy bundle..."
-rm -rf "/Library/Security/SecurityAgentPlugins/Bootstrap Buddy.bundle"
+create_workspace() {
+    BB_DIR=$(/usr/bin/mktemp -d "${TMPDIR:-/private/tmp}/com.inetum.Bootstrap-Buddy.XXXXXX") || fail "Unable to create a temporary workspace."
+    AUTH_DB="${BB_DIR}/auth.db"
+}
 
-echo "Forgetting receipt..."
-pkgutil --forget "com.inetum.Bootstrap-Buddy" 2>/dev/null
+read_auth_db() {
+    log "Reading ${AUTH_DB_SECTION} section of authorization database..."
 
-echo "Bootstrap Buddy successfully uninstalled."
+    if ! /usr/bin/security authorizationdb read "${AUTH_DB_SECTION}" > "${AUTH_DB}"; then
+        fail "Unable to read the current authorization database."
+    fi
+
+    if [[ ! -s "${AUTH_DB}" ]]; then
+        fail "Authorization database output is empty."
+    fi
+
+    if ! /usr/bin/plutil -lint "${AUTH_DB}" >/dev/null; then
+        fail "Authorization database output is not a valid property list."
+    fi
+}
+
+authdb_has_mechanism() {
+    grep -Fq "<string>${MECHANISM_LABEL}</string>" "${AUTH_DB}"
+}
+
+find_mechanism_index() {
+    local raw_index
+
+    raw_index="$(
+        /usr/libexec/PlistBuddy -c "Print :mechanisms:" "${AUTH_DB}" 2>/dev/null \
+            | grep -nF "${MECHANISM_LABEL}" \
+            | awk -F ":" 'NR == 1 { print $1 }' || true
+    )"
+
+    if [[ -z "${raw_index}" ]]; then
+        return 1
+    fi
+
+    raw_index=$((raw_index - 2))
+    if (( raw_index < 0 )); then
+        return 1
+    fi
+
+    echo "${raw_index}"
+}
+
+run_internal_teardown() {
+    local mechanism_index
+
+    read_auth_db
+    if ! authdb_has_mechanism; then
+        log "Bootstrap Buddy is not configured in the loginwindow authorization database."
+        return 0
+    fi
+
+    cp "${AUTH_DB}" "${AUTH_DB}.backup" || fail "Unable to back up the current authorization database."
+
+    mechanism_index="$(find_mechanism_index)" || fail "Unable to locate Bootstrap Buddy in the current authorization database."
+
+    log "Removing Bootstrap Buddy from authorization database..."
+    if ! /usr/libexec/PlistBuddy -c "Delete :mechanisms:${mechanism_index}" "${AUTH_DB}"; then
+        fail "Unable to remove Bootstrap Buddy from the authorization database."
+    fi
+
+    if ! /usr/bin/security authorizationdb write "${AUTH_DB_SECTION}" < "${AUTH_DB}"; then
+        fail "Unable to save changes to the authorization database."
+    fi
+}
+
+ensure_authdb_mechanism_removed() {
+    if [[ -x "${BUNDLED_TEARDOWN}" ]]; then
+        log "Running bundled authorization database teardown..."
+        if "${BUNDLED_TEARDOWN}"; then
+            read_auth_db
+            if ! authdb_has_mechanism; then
+                return 0
+            fi
+
+            log "Bundled teardown completed, but Bootstrap Buddy is still configured in the authorization database."
+        else
+            log "Bundled teardown failed."
+        fi
+
+        log "Falling back to built-in authorization database teardown..."
+    fi
+
+    run_internal_teardown
+    read_auth_db
+    if authdb_has_mechanism; then
+        fail "Bootstrap Buddy is still configured in the authorization database. Aborting before removing the bundle."
+    fi
+}
+
+remove_bundle() {
+    if [[ ! -e "${BUNDLE_PATH}" ]]; then
+        log "Bootstrap Buddy bundle is already absent."
+        return 0
+    fi
+
+    log "Deleting Bootstrap Buddy bundle..."
+    rm -rf "${BUNDLE_PATH}" || fail "Unable to delete the Bootstrap Buddy bundle."
+
+    if [[ -e "${BUNDLE_PATH}" ]]; then
+        fail "Bootstrap Buddy bundle still exists after deletion."
+    fi
+}
+
+forget_receipt() {
+    if ! /usr/sbin/pkgutil --pkg-info "${RECEIPT_ID}" >/dev/null 2>&1; then
+        log "Bootstrap Buddy receipt is already absent."
+        return 0
+    fi
+
+    log "Forgetting receipt..."
+    if ! /usr/sbin/pkgutil --forget "${RECEIPT_ID}" >/dev/null; then
+        fail "Unable to forget package receipt ${RECEIPT_ID}."
+    fi
+}
+
+main() {
+    trap cleanup EXIT
+
+    require_root
+    create_workspace
+    read_auth_db
+
+    if authdb_has_mechanism; then
+        ensure_authdb_mechanism_removed
+    else
+        log "Bootstrap Buddy is not configured in the loginwindow authorization database."
+    fi
+
+    remove_bundle
+    forget_receipt
+
+    log "Bootstrap Buddy successfully uninstalled."
+}
+
+main "$@"


### PR DESCRIPTION
## fix(uninstall): harden uninstall flow and fail closed

Refactor scripts/uninstall.sh to make the uninstall path safe for
production use and resilient to partial failures.

The previous implementation could continue after a failed
`security authorizationdb read`, because shell redirection created the
temporary file even when the command itself failed. That made it
possible to remove the Bootstrap Buddy bundle while leaving the
authorization database entry behind, which is not a safe uninstall
outcome.

This change hardens the script by:

- enabling strict shell behavior with `set -euo pipefail`
- requiring root execution up front
- using a dedicated temporary workspace with cleanup on exit
- validating that authorization DB reads succeed, produce content, and
  return a valid plist
- checking whether the Bootstrap Buddy mechanism is present before
  attempting teardown
- preferring the bundled teardown script, but falling back to an
  internal teardown path when needed
- verifying that the authorization DB entry is actually gone before
  removing the bundle
- making bundle removal and receipt forgetting idempotent when the
  system is already partially uninstalled
- failing with explicit errors instead of printing success after a
  partial or inconsistent uninstall

The result is an uninstall flow that is safer to run from MDM or manual
recovery workflows and less likely to leave the loginwindow
authorization database in a broken state.